### PR TITLE
[Fix] 로그인, 회원가입 페이지 오류 수정

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './Login.scss';
 
 import { useAppSelector, useAppDispatch } from '../app/hooks';
@@ -8,6 +8,13 @@ const Login: React.FC = () => {
   const userInfo = useAppSelector((state) => state.userInfo.info);
   const errMessage = useAppSelector((state) => state.userInfo.error);
   const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    window.addEventListener('popstate', (event) => {
+      alert('모든 데이터가 삭제됩니다.');
+      window.location.reload();
+    });
+  }, []);
 
   const handleSubmit = () => {
     let value = false;

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './SignUp.scss';
 
 import { useAppSelector, useAppDispatch } from '../app/hooks';
@@ -8,6 +8,13 @@ const SignUp: React.FC = () => {
   const userInfo = useAppSelector((state) => state.userInfo.info);
   const errMessage = useAppSelector((state) => state.userInfo.error);
   const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    window.addEventListener('popstate', (event) => {
+      alert('모든 데이터가 삭제됩니다.');
+      window.location.reload();
+    });
+  }, []);
 
   const handleSubmit = () => {
     let value = false;

--- a/src/features/form/userInfoSlice.ts
+++ b/src/features/form/userInfoSlice.ts
@@ -1,21 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
+import { valuesInterface, errorsInterface } from './form.model';
 
 import validate from './validate';
 
 interface userInfoState {
-  info: {
-    email: string,
-    password: string,
-    password2: string,
-    [key: string]: string,
-  };
-  error: {
-    email: string,
-    password: string,
-    password2: string,
-    [key: string]: string,
-  };
+  info: valuesInterface;
+  error: errorsInterface;
 }
 
 interface info {

--- a/src/features/form/validate.ts
+++ b/src/features/form/validate.ts
@@ -7,22 +7,19 @@ export default function validate(values: valuesInterface): errorsInterface {
     password2: '',
   };
 
-  if (!values.email) {
-    errors.email = '이메일을 입력하세요.';
-  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)) {
+  if (
+    values.email.length > 0 &&
+    !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)
+  ) {
     errors.email = '이메일 형식이 맞지 않습니다.';
   }
 
-  if (!values.password) {
-    errors.password = '비밀번호를 입력하세요.';
-  } else if (values.password.length < 6) {
+  if (values.password.length > 0 && values.password.length < 6) {
     errors.password = '비밀번호는 6자 이상입니다.';
   }
 
-  if (!values.password2) {
-    errors.password2 = '비밀번호를 입력하세요.';
-  } else if (values.password2 !== values.password) {
-    errors.password2 = '비밀번호가 맞지 않습니다';
+  if (values.password2.length > 0 && values.password2 !== values.password) {
+    errors.password2 = '비밀번호가 맞지 않습니다.';
   }
 
   return errors;


### PR DESCRIPTION
- 각페이지에서 뒤로가기 버튼 클릭시, 새로고침 기능 구현
(기존의 경우, router로 이동할때 redux의 store에 state 값이 남아있어 
로그인에서 작성한 state 값이 회원가입 페이지에서 보여지는 오류 발생)
- input창에 정보입력시, 모든 input의 에러가 보여지는 오류 수정
validate의 코드 중 값의 유무 대신 값의 길이가 1보다 클 때로 오류를 검사하는 코드로 수정
(input창에 정보를 입력하면 기존의 유효성 검사는 input창의 정보의 
유무로 검사를 하여 아직 작성하지 않은 input창에 오류 메시지를 보여줬음)

- form.model.ts에서 작성한 interface를 userInfoSlice에서 사용하여 코드를 줄임