### PR TITLE
[Fix] 회원가입, 로그인 컴포넌트 state 관리 변경(redux store => useState)

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,53 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import './Login.scss';
 import AlertModal from './alert/AlertModal';
 
-import { useAppSelector, useAppDispatch } from '../app/hooks';
-import { makeUserInfo } from '../features/form/userInfoSlice';
-import { handleModal } from '../features/modal/modalSlice';
+import useForm from '../features/form/useForm';
 
 const Login: React.FC = () => {
-  const userInfo = useAppSelector((state) => state.userInfo.info);
-  const errMessage = useAppSelector((state) => state.userInfo.error);
-  const dispatch = useAppDispatch();
-
-  const handleSubmit = () => {
-    let value = false;
-    let error = true;
-
-    for (let key in userInfo) {
-      if (key === 'password2') {
-        value = true;
-      } else {
-        // console.log(userInfo[key]);
-        if (userInfo[key].length > 0) {
-          value = true;
-        } else {
-          value = false;
-          break;
-        }
-      }
-    }
-
-    for (let key in errMessage) {
-      if (key === 'password2') {
-        error = false;
-      } else {
-        if (errMessage[key].length > 0) {
-          error = true;
-          break;
-        } else {
-          error = false;
-        }
-      }
-    }
-
-    if (value && !error) {
-      console.log(userInfo);
-    } else {
-      dispatch(handleModal({ show: true, type: 'alert' }));
-    }
-  };
+  const { handleChange, handleSubmit, values, errors } = useForm();
 
   return (
     <div className="login_wrap">
@@ -62,34 +20,24 @@ const Login: React.FC = () => {
             type="text"
             placeholder="Enter your Email"
             autoComplete="off"
-            onChange={(event) =>
-              dispatch(
-                makeUserInfo({
-                  name: event.target.name,
-                  value: event.target.value,
-                }),
-              )
-            }
+            value={values.email}
+            onChange={handleChange}
           />
-          <p className="error_message">{errMessage.email}</p>
+          {errors.email && <p className="error_message">{errors.email}</p>}
         </div>
         <div className="input_container">
           <input
             name="password"
             type="password"
             placeholder="Enter your Password"
-            onChange={(event) =>
-              dispatch(
-                makeUserInfo({
-                  name: event.target.name,
-                  value: event.target.value,
-                }),
-              )
-            }
+            value={values.password}
+            onChange={handleChange}
           />
-          <p className="error_message">{errMessage.password}</p>
+          {errors.password && (
+            <p className="error_message">{errors.password}</p>
+          )}
         </div>
-        <button className="login_btn" onClick={() => handleSubmit()}>
+        <button className="login_btn" onClick={() => handleSubmit('login')}>
           Continue
         </button>
       </div>

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -2,48 +2,10 @@ import React from 'react';
 import './SignUp.scss';
 import AlertModal from './alert/AlertModal';
 
-import { useAppSelector, useAppDispatch } from '../app/hooks';
-import { makeUserInfo } from '../features/form/userInfoSlice';
-import { handleModal } from '../features/modal/modalSlice';
+import useForm from '../features/form/useForm';
 
 const SignUp: React.FC = () => {
-  const userInfo = useAppSelector((state) => state.userInfo.info);
-  const errMessage = useAppSelector((state) => state.userInfo.error);
-  const dispatch = useAppDispatch();
-
-  const handleSubmit = () => {
-    let value = false;
-    let error = true;
-
-    for (let key in userInfo) {
-      // console.log(userInfo[key]);
-      if (userInfo[key].length > 0) {
-        value = true;
-      } else {
-        value = false;
-        break;
-      }
-    }
-
-    for (let key in errMessage) {
-      if (errMessage[key].length > 0) {
-        error = true;
-        break;
-      } else {
-        error = false;
-      }
-    }
-
-    console.log('value :', value);
-    console.log('err :', error);
-
-    if (value && !error) {
-      console.log(userInfo);
-    } else {
-      // alert('다시 한번 확인해주세요');
-      dispatch(handleModal({ show: true, type: 'alert' }));
-    }
-  };
+  const { handleChange, handleSubmit, values, errors } = useForm();
 
   return (
     <div className="sign_up_wrap">
@@ -56,55 +18,38 @@ const SignUp: React.FC = () => {
           <input
             name="email"
             type="text"
-            value={userInfo.email}
             placeholder="Enter your Email"
             autoComplete="off"
-            onChange={(event) =>
-              dispatch(
-                makeUserInfo({
-                  name: event.target.name,
-                  value: event.target.value,
-                }),
-              )
-            }
+            value={values.email}
+            onChange={handleChange}
           />
-          <p className="error_message">{errMessage.email}</p>
+          {errors.email && <p className="error_message">{errors.email}</p>}
         </div>
         <div className="input_container">
           <input
             name="password"
             type="password"
-            value={userInfo.password}
+            value={values.password}
             placeholder="Enter your Password"
-            onChange={(event) =>
-              dispatch(
-                makeUserInfo({
-                  name: event.target.name,
-                  value: event.target.value,
-                }),
-              )
-            }
+            onChange={handleChange}
           />
-          <p className="error_message">{errMessage.password}</p>
+          {errors.password && (
+            <p className="error_message">{errors.password}</p>
+          )}
         </div>
         <div className="input_container">
           <input
             name="password2"
             type="password"
-            value={userInfo.password2}
+            value={values.password2}
             placeholder="Enter your Password Again"
-            onChange={(event) =>
-              dispatch(
-                makeUserInfo({
-                  name: event.target.name,
-                  value: event.target.value,
-                }),
-              )
-            }
+            onChange={handleChange}
           />
-          <p className="error_message">{errMessage.password2}</p>
+          {errors.password2 && (
+            <p className="error_message">{errors.password2}</p>
+          )}
         </div>
-        <button className="sign_up_btn" onClick={() => handleSubmit()}>
+        <button className="sign_up_btn" onClick={() => handleSubmit('sign_up')}>
           Continue
         </button>
       </div>
@@ -125,3 +70,19 @@ export default SignUp;
 //     //history.pushState(null, document.title, location.href);
 //   });
 // }, []);
+
+// onChange 함수와 redux 사용 코드
+// <input
+// name="password2"
+// type="password"
+// value={userInfo.password2}
+// placeholder="Enter your Password Again"
+// onChange={(event) =>
+//   dispatch(
+//     makeUserInfo({
+//       name: event.target.name,
+//       value: event.target.value,
+//     }),
+//   )
+// }
+// />

--- a/src/features/form/form.model.ts
+++ b/src/features/form/form.model.ts
@@ -1,13 +1,13 @@
-export interface valuesInterface {
+export interface formInterface {
   email: string;
   password: string;
   password2: string;
   [key: string]: string;
 }
 
-export interface errorsInterface {
-  email: string;
-  password: string;
-  password2: string;
-  [key: string]: string;
-}
+// export interface errorsInterface {
+//   email: string;
+//   password: string;
+//   password2: string;
+//   [key: string]: string;
+// }

--- a/src/features/form/useForm.ts
+++ b/src/features/form/useForm.ts
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import validate from './validate';
+import { formInterface } from './form.model';
+import { useAppDispatch } from '../../app/hooks';
+import { handleModal } from '../modal/modalSlice';
+
+const useForm = () => {
+  const dispatch = useAppDispatch();
+
+  const [values, setValues] = useState<formInterface>({
+    email: '',
+    password: '',
+    password2: '',
+  });
+
+  const [errors, setErrors] = useState<formInterface>({
+    email: '',
+    password: '',
+    password2: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    let newValue = { ...values, [name]: value };
+
+    setValues(newValue);
+    setErrors(validate(newValue));
+  };
+
+  const checkState = (state: boolean, obj: formInterface, type: string) => {
+    for (let key in obj) {
+      if (type === 'login' && key === 'password2') {
+        break;
+      } else {
+        if (obj[key].length > 0) {
+          state = true;
+        } else {
+          state = false;
+          break;
+        }
+      }
+    }
+    return state;
+  };
+
+  const handleSubmit = (type: string) => {
+    let valueChk = false;
+    let errorChk = true;
+
+    valueChk = checkState(valueChk, values, type);
+    errorChk = checkState(errorChk, errors, type);
+
+    if (valueChk && !errorChk) {
+      console.log(values);
+    } else {
+      dispatch(handleModal({ show: true, type: 'alert' }));
+    }
+  };
+
+  return { handleChange, handleSubmit, values, errors };
+};
+
+export default useForm;

--- a/src/features/form/userInfoSlice.ts
+++ b/src/features/form/userInfoSlice.ts
@@ -1,12 +1,15 @@
+// 로그인, 회원가입의 input 관리를 전역이 아닌 컴포넌트내부에서
+// 관리하기로 결정, 현재는 필요없는 파일이다.(0524 기준)
+
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
-import { valuesInterface, errorsInterface } from './form.model';
+import { formInterface } from './form.model';
 
 import validate from './validate';
 
 interface userInfoState {
-  info: valuesInterface;
-  error: errorsInterface;
+  info: formInterface;
+  error: formInterface;
 }
 
 interface info {

--- a/src/features/form/validate.ts
+++ b/src/features/form/validate.ts
@@ -1,7 +1,7 @@
-import { valuesInterface, errorsInterface } from './form.model';
+import { formInterface } from './form.model';
 
-export default function validate(values: valuesInterface): errorsInterface {
-  let errors: errorsInterface = {
+export default function validate(values: formInterface): formInterface {
+  let errors: formInterface = {
     email: '',
     password: '',
     password2: '',


### PR DESCRIPTION
- 각컴포넌트에서 작성하는 상태값을 전역관리할 필요가 없다고 판단하여 
redux store가 아닌 해당 컴포넌트에서 useState로 관리한다.
- useForm이라는 커스텀훅을 만들어 해당 훅에서 values, errors의 state를 관리하고 
state를 변경하는 함수를 만들어 로그인과 회원가입 컴포넌트에 전달한다.
- 기존의 handleSubmit 함수에서 코드가 불필요하게 반복된다고 판단하여
  checkState라는 함수를 따로 만들어 코드의 길이를 줄였다.
- form.model.ts에 있는 value와 error의 인터페이스가 같은 타입이기 때문에
  formInterface로 통합하였다.
- 전역상태관리를 하지 않기 때문에 userInfoSlice는 필요없는 파일이
  되었지만 이후의 공부를 이후 삭제하지 않는다.

---------------------------

전역상태관리에서 컴포넌트 내부 상태관리로 변경한 이유
- 해당 state가 전역으로 필요한지에 대한 고민이 있었고 불필요하다고 판단하였다.
- 전역으로 state를 공유하고 있기때문에 하나의 컴포넌트에서 작성한 state 값이
route로 이동할 경우, state 값을 공유하는 오류가 발생하였다.
- 이를 해결하기 위해 뒤로가기 버튼 클릭시, 새로고침 또는 redux store의 초기화 등의 고민을 하였으나 
해당 문제를 해결하는 것보다 상태관리 방법을 변경하는 것이 더욱 효율적이라고 판단하여 변경하였다.