### PR TITLE
[ADD] Main 페이지, 명언 api call 기능 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,6 @@
     "semi": true,
     "useTabs": false,
     "tabWidth": 2,
-    "trailingComma": "all",
+    "trailingComma": "none",
     "printWidth": 80
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,12 +1,15 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import userInfoReducer from '../features/form/userInfoSlice';
 import modalReducer from '../features/modal/modalSlice';
+import quotesReducer from '../features/quotes/fetchQuotesSlice';
 
 export const store = configureStore({
   reducer: {
     userInfo: userInfoReducer,
     showModal: modalReducer,
+    quotes: quotesReducer
   },
+  middleware: [...getDefaultMiddleware()]
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/components/Main.scss
+++ b/src/components/Main.scss
@@ -30,9 +30,11 @@
         margin: 3px auto;
 
     }
-    .phrase_section {
+    .quotes_section {
         height: 30%;
-        .phrase {
+        border: 1px solid red;
+        position: relative;
+        .quotes {
             padding-top: 10%;
             margin-left: 5%;
             width: 70%;
@@ -40,6 +42,23 @@
             font-size: 38px;
             font-weight: bold;
             text-decoration: underline;
+        }
+        .long_quotes {
+            padding-top: 5%;
+            margin-left: 5%;
+            width: 75%;
+            color: #3E2B84;
+            font-size: 24px;//38px;
+            font-weight: bold;
+            text-decoration: underline;
+        }
+        .author{
+            position: absolute;
+            border: 1px solid blue;
+            right: 5%;
+            bottom: 0;
+            color: #3E2B84;
+            font-weight: bold;
         }
     }
     .date_section {

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,7 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './Main.scss';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
+import { fetchQuotes } from '../features/quotes/fetchQuotesSlice';
 
 const Main: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const quotes = useAppSelector((state) => state.quotes.quotes);
+
+  useEffect(() => {
+    const randomNum = getRanNum();
+    dispatch(fetchQuotes(randomNum));
+  }, []);
+
+  const getRanNum = () => {
+    const randomNum = Math.random() * 1400;
+    const randomNumFloor = Math.floor(randomNum);
+    return randomNumFloor;
+  };
+
   return (
     <div className="main_wrap">
       <div className="main_header">
@@ -9,11 +25,17 @@ const Main: React.FC = () => {
       </div>
       <hr className="header_line"></hr>
       <hr className="header_line"></hr>
-      <div className="phrase_section">
-        <div className="phrase">
-          To live is to suffer, to survive is to find some meaing in the
-          suffering.
-        </div>
+      <div className="quotes_section">
+        {quotes.text !== undefined ? (
+          <>
+            <div className={quotes.text.length > 80 ? `long_quotes` : `quotes`}>
+              {quotes.text}
+            </div>
+            <div className="author">
+              {quotes.author !== null ? `- ${quotes.author}` : null}
+            </div>
+          </>
+        ) : null}
       </div>
       <div className="date_section">
         <div className="today">25</div>

--- a/src/features/modal/modalSlice.ts
+++ b/src/features/modal/modalSlice.ts
@@ -8,7 +8,7 @@ interface modalState {
 
 const initialState: modalState = {
   show: false,
-  type: '',
+  type: ''
 };
 
 export const modalSlice = createSlice({
@@ -18,8 +18,8 @@ export const modalSlice = createSlice({
     handleModal: (state, action: PayloadAction<modalState>) => {
       state.show = action.payload.show;
       state.type = action.payload.type;
-    },
-  },
+    }
+  }
 });
 
 export const { handleModal } = modalSlice.actions;

--- a/src/features/quotes/fetchQuotesSlice.ts
+++ b/src/features/quotes/fetchQuotesSlice.ts
@@ -1,0 +1,81 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../../app/store';
+
+type QuotesType = {
+  text: string,
+  author: string | null
+};
+
+type FetchQuotesError = {
+  message: string
+}
+
+// First, create the thunk
+export const fetchQuotes = createAsyncThunk<QuotesType, number,{rejectValue: FetchQuotesError}>(
+  'fetchQuotes',
+
+  //rejectWithValue를 위해 필요없는 파라미터 '_'를 사용함
+  //이게 없으면 rejectWithValue는 void 형식의 오류를 발생시킨다.
+  async (number, thunkApi) => {
+    try {
+      const response = await fetch('https://type.fit/api/quotes');
+      const data: QuotesType[] = await response.json();
+      return data[number]
+
+    } catch(err) {
+      return thunkApi.rejectWithValue({
+        message: 'Failed to fetch Quotes'
+      })
+     
+    }
+
+  }
+);
+
+
+
+type QuotesDataState = {
+  quotes: QuotesType,
+  status: 'loading' | 'idle',
+  error: string | null
+};
+
+const initialState = {
+    quotes: {},
+    error: null,
+    status: 'idle'
+// eslint-disable-next-line prettier/prettier
+} as QuotesDataState
+
+const fetchQuotesSlice = createSlice({
+  name: 'quotes',
+  initialState,
+  reducers: {
+
+  },
+  extraReducers: (builder) => {
+    // When we send a request,
+    // fetchQuotes.pending is being fired:
+    builder.addCase(fetchQuotes.pending, (state) => {
+      state.status = 'loading';
+      state.error = null
+    })
+
+    // When a sercer responses with the data,
+    // 'fetchQuotes.fulfilled' is firderd
+    builder.addCase(fetchQuotes.fulfilled, (state, {payload}) => {
+      //console.log('quotes', payload)
+      state.quotes = payload;
+      state.status = 'idle'
+    })
+
+     // When a server responses with an error:
+     builder.addCase(fetchQuotes.rejected, (state, { payload }) => {
+      console.log(payload)
+     })
+  }
+})
+
+export const selectQuotes = (state: RootState) => state.quotes;
+
+export default fetchQuotesSlice.reducer;


### PR DESCRIPTION
- 메인페이지에서 명언 보여주는 기능 구현
- reduxtoolkit의 미들웨어 thunk를 활용한 명언 api call
- 기능 구현을 위한 fetchQuotesSlice 파일 생성, app/store 코드 수정
- main 페이지 렌더링(useEffect)시, api call
- api call의 응답을 메인페이지 quotes_section 에 보여줌