### PR TITLE
[Fix] DiarySlice interface(type) 정리(리팩토링)

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -5,6 +5,7 @@ import quotesReducer from '../features/quotes/fetchQuotesSlice';
 import calendarReducer from '../features/calendar/calendarSlice';
 import weatherReducer from '../features/weather/fetchWeatherSlice';
 import diaryReducer from '../features/diary/diarySlice';
+import listReducer from '../features/fetchList/fetchListSlice';
 
 export const store = configureStore({
   reducer: {
@@ -13,7 +14,8 @@ export const store = configureStore({
     quotes: quotesReducer,
     handleCalendar: calendarReducer,
     weather: weatherReducer,
-    diary: diaryReducer
+    diary: diaryReducer,
+    list: listReducer
   }
   //middleware: [...getDefaultMiddleware()]
 });

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,19 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import './Main.scss';
+import { Link } from 'react-router-dom';
+
 import CalendarIcon from './icons/CalendarIcon';
 import WeatherIcon from './icons/WeatherIcon';
 import TodayInfo from '../components/todayInfo/TodayInfo';
 import DiaryRecordList from '../components/diaryList/DiaryRecordList';
-
-import { Link } from 'react-router-dom';
+import ReactDayPicker from './calendar/ReactDayPicker';
 
 import { useAppDispatch, useAppSelector } from '../app/hooks';
+
 import { fetchQuotes } from '../features/quotes/fetchQuotesSlice';
-
-import ReactDayPicker from './calendar/ReactDayPicker';
 import { showCalendar } from '../features/calendar/calendarSlice';
-
-import { handleList } from './../features/diary/diarySlice';
+import { handleList } from '../features/fetchList/fetchListSlice';
 
 // {}가 없을 경우, type error 발생
 //import fetchWeather from '../features/weather/fetchWeatherSlice';
@@ -35,16 +34,7 @@ const Main: React.FC = () => {
     (state) => state.handleCalendar.selectDate
   );
   const weather = useAppSelector((state) => state.weather.weather);
-
-  const [loadedDiary, setLoadedDiary] = useState<Diary[]>([]);
-  // const [diary, setDiary] = useState<Diary>({
-  //   id: 0,
-  //   date: '',
-  //   emotion: '',
-  //   content: ['']
-  // });
-  // const [selectDay, setSelectDay] = useState<string>('');
-  const [dayCheck, setDayCheck] = useState<boolean>(false);
+  const list = useAppSelector((state) => state.list.totalList);
 
   useEffect(() => {
     const randomNum = getRanNum();
@@ -57,26 +47,7 @@ const Main: React.FC = () => {
       const parsedList = JSON.parse(loadedList);
       dispatch(handleList(parsedList));
     }
-    //  const day = calendarToStr(calendar);
-
-    //   for (let i = 0; i < newList.length; i++) {
-    //     if (newList[i].date === day) {
-    //       setDayCheck(true);
-    //       setDiary(newList[i]);
-    //       break;
-    //     } else {
-    //       setDayCheck(false);
-    //     }
-    //   }
-    // }
-
-    // setSelectDay(calendarToStr(calendar));
   }, []);
-
-  const calendarToStr = (str: string) => {
-    const result = str.slice(-str.length, str.indexOf('오') - 2);
-    return result;
-  };
 
   const getRanNum = () => {
     const randomNum = Math.random() * 1400;
@@ -114,7 +85,7 @@ const Main: React.FC = () => {
         ) : null}
       </div>
       <TodayInfo />
-      {/* <DiaryRecordList /> */}
+      <DiaryRecordList />
     </div>
   );
 };

--- a/src/components/diary/DiarySlider.tsx
+++ b/src/components/diary/DiarySlider.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import './DiarySlider.scss';
 import Emotion from './Emotion';
 import Question from './Question';
-import { IconContext } from 'react-icons';
-import { BiCheck, BiLeftArrowAlt, BiRightArrowAlt } from 'react-icons/bi';
+//import { IconContext } from 'react-icons';
+import { BiLeftArrowAlt, BiRightArrowAlt } from 'react-icons/bi';
 
 import { useAppSelector } from '../../app/hooks';
 
@@ -29,7 +29,7 @@ const DiarySlider: React.FC = () => {
   const [nextRef, setNextRef] = useState<any>();
 
   const questionList = useAppSelector((state) => state.diary.questionList);
-  const answer = useAppSelector((state) => state.diary.answer);
+  const answer = useAppSelector((state) => state.diary.answerList);
 
   useEffect(() => {
     //useState를 사용하지 않으면 ref로 지정해도

--- a/src/components/diary/Question.tsx
+++ b/src/components/diary/Question.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import './Question.scss';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { IconContext } from 'react-icons';
 import { BiCheck } from 'react-icons/bi';
 
-import { RouteComponentProps, withRouter } from 'react-router';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 
 import { handleAnswer } from '../../features/diary/diarySlice';
+import { ListInterface } from '../../features/fetchList/list.model';
 
 interface QuestionComponentProps extends RouteComponentProps<any> {
   question: any;
@@ -15,37 +16,20 @@ interface QuestionComponentProps extends RouteComponentProps<any> {
 
 const DIARY_LS = 'diary_list';
 
-interface DayInfo {
-  today: number;
-  month: string;
-  day: string;
-}
-
-interface Diary {
-  id: number;
-  date: string;
-  emotion: string;
-  //content: string[];
-  dayInfo: DayInfo;
-  list: any;
-}
 //history와 부모 컴포넌트에서 내려오는 props를 같이 사용하려면
 //(props, {history}) 가 아닌 props로 전부를 받아와 사용해야한다.
 //(props, {history}) 형태의 경우, 두번째 인자의 값을 undefined로 받음.
 const Question: React.FC<QuestionComponentProps> = (props) => {
-  //console.log('history', history);
-  //console.log('props:', props);
-
   const dispatch = useAppDispatch();
   const currentDate = useAppSelector(
     (state) => state.handleCalendar.selectDate
   );
   const emotion = useAppSelector((state) => state.diary.emotion);
   const dayInfo = useAppSelector((state) => state.handleCalendar.dayInfo);
-  const answer = useAppSelector((state) => state.diary.answer);
+  const answer = useAppSelector((state) => state.diary.answerList);
 
   const [value, setValue] = useState<string>('1. ');
-  const [loadedDiary, setLoadedDiary] = useState<Diary[]>([]);
+  const [loadedDiary, setLoadedDiary] = useState<ListInterface[]>([]);
 
   useEffect(() => {
     const loadedList = localStorage.getItem(DIARY_LS);
@@ -81,13 +65,12 @@ const Question: React.FC<QuestionComponentProps> = (props) => {
   };
 
   const postDiary = () => {
-    const postData: Diary = {
+    const postData: ListInterface = {
       id: loadedDiary.length + 1,
       date: currentDate,
       emotion: emotion,
-      //content: value.split('\n'),
       dayInfo: dayInfo,
-      list: answer
+      answerList: answer
     };
 
     const newList = [...loadedDiary, postData];

--- a/src/components/diaryList/DiaryRecord.tsx
+++ b/src/components/diaryList/DiaryRecord.tsx
@@ -14,7 +14,9 @@ const DiaryRecord: React.FC<DiaryRecordProps> = (props) => {
         <div className="list_day">{record.dayInfo.day}</div>
         <div className="list_date">{record.dayInfo.today}</div>
       </div>
-      <div className="list_content_box">{record.content[0]}</div>
+      <div className="list_content_box">
+        {record.answerList['오늘의 다짐'][0]}
+      </div>
     </div>
   );
 };

--- a/src/components/diaryList/DiaryRecordList.tsx
+++ b/src/components/diaryList/DiaryRecordList.tsx
@@ -4,8 +4,9 @@ import DiaryRecord from './DiaryRecord';
 
 import { useAppSelector } from '../../app/hooks';
 
-const DiaryList: React.FC = () => {
-  const list = useAppSelector((state) => state.diary.list);
+const DiaryRecordList: React.FC = () => {
+  //const list = useAppSelector((state) => state.diary.list);
+  const list = useAppSelector((state) => state.list.totalList);
 
   const renderList = () => {
     if (list) {
@@ -29,7 +30,7 @@ const DiaryList: React.FC = () => {
   return <div className="diary_list_wrap">{renderList()}</div>;
 };
 
-export default DiaryList;
+export default DiaryRecordList;
 
 // return list.map((el, key) => {
 //   return <DiaryRecord record={el} key={el.id} />;

--- a/src/components/todayInfo/TodayInfo.tsx
+++ b/src/components/todayInfo/TodayInfo.tsx
@@ -10,7 +10,8 @@ const TodayInfo: React.FC = () => {
   const currentDate = useAppSelector(
     (state) => state.handleCalendar.selectDate
   );
-  const list = useAppSelector((state) => state.diary.list);
+  //const list = useAppSelector((state) => state.diary.list);
+  const list = useAppSelector((state) => state.list.totalList);
 
   const { getDate, dateInfo } = useCalendar();
 

--- a/src/features/diary/diary.model.ts
+++ b/src/features/diary/diary.model.ts
@@ -1,0 +1,24 @@
+export interface DiaryData {
+  emotion: string;
+  questionList: string[];
+  //list: List[]; // 전체 다이어리 리스트를 관리하는 state 위치에 대해 고민이 필요하다.
+  answerList: AnswerList;
+}
+
+interface List {
+  id: number;
+  date: string;
+  emotion: string;
+  content: string[];
+}
+
+// const data1: DiaryData = {
+//   emotion: 'good',
+//   list: null,
+//   answerList: {'dkd':['asfsdf']},
+//   questionList: [1,2,3]
+// }
+
+interface AnswerList {
+  [question: string]: string[];
+}

--- a/src/features/diary/diarySlice.ts
+++ b/src/features/diary/diarySlice.ts
@@ -1,43 +1,45 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 
-interface List {
-  id: number;
-  date: string;
-  emotion: string;
-  content: string[];
-}
+import { DiaryData } from './diary.model';
 
-interface Answer {
-  '내가 감사하게 생각하는 것들': string[];
-  '오늘을 기분좋게 만들어주는 것은?': string[];
-  '오늘의 다짐': string[];
-}
+// interface List {
+//   id: number;
+//   date: string;
+//   emotion: string;
+//   content: string[];
+// }
 
-interface Diary {
-  emotion: string;
-  questionList: string[];
-  list: List[];
-  answer: Answer;
-}
+// interface Answer {
+//   '내가 감사하게 생각하는 것들': string[];
+//   '오늘을 기분좋게 만들어주는 것은?': string[];
+//   '오늘의 다짐': string[];
+// }
 
-interface AnswerQuestion {
+// interface Diary {
+//   emotion: string;
+//   questionList: string[];
+//   list: List[];
+//   answer: Answer;
+// }
+
+interface AnswerToQuestion {
   question: string;
   value: string;
 }
 
-const initialState: Diary = {
+const initialState: DiaryData = {
   emotion: 'great',
   questionList: [
     '내가 감사하게 생각하는 것들',
     '오늘을 기분좋게 만들어주는 것은?',
     '오늘의 다짐'
   ],
-  list: [],
-  answer: {
-    '내가 감사하게 생각하는 것들': [''],
-    '오늘을 기분좋게 만들어주는 것은?': [''],
-    '오늘의 다짐': ['']
+  //list: [],
+  answerList: {
+    '내가 감사하게 생각하는 것들': ['1. '],
+    '오늘을 기분좋게 만들어주는 것은?': ['1. '],
+    '오늘의 다짐': ['1. ']
   }
 };
 
@@ -50,21 +52,25 @@ export const diarySlice = createSlice({
       //console.log('action: ', action);
       state.emotion = action.payload;
     },
-    handleList: (state, action) => {
-      state.list = action.payload;
-    },
-    handleAnswer: (state, action: PayloadAction<AnswerQuestion>) => {
+    // handleList: (state, action) => {
+    //   state.list = action.payload;
+    // },
+    handleAnswer: (state, action: PayloadAction<AnswerToQuestion>) => {
       //console.log(action.payload);
       const { question, value } = action.payload;
       //console.log(question);
       //console.log(value);
       //console.log(value.split('\n'));
-      state.answer = { ...state.answer, [question]: value.split('\n') };
+
+      state.answerList = {
+        ...state.answerList,
+        [question]: value.split('\n')
+      };
     }
   }
 });
 
-export const { handleEmotion, handleList, handleAnswer } = diarySlice.actions;
+export const { handleEmotion, handleAnswer } = diarySlice.actions;
 
 export const diary = (state: RootState) => state.diary;
 

--- a/src/features/fetchList/fetchListSlice.ts
+++ b/src/features/fetchList/fetchListSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../../app/store';
+
+import { ListInterface } from './list.model';
+
+interface fetchList {
+  totalList: ListInterface[];
+  selectList: ListInterface | any;
+}
+
+const initialState: fetchList = {
+  totalList: [],
+  selectList: {}
+};
+
+export const fetchListSlice = createSlice({
+  name: 'list',
+  initialState,
+  reducers: {
+    handleList: (state, action) => {
+      state.totalList = action.payload;
+    }
+  }
+});
+
+export const { handleList } = fetchListSlice.actions;
+
+export const list = (state: RootState) => state.list;
+
+export default fetchListSlice.reducer;

--- a/src/features/fetchList/list.model.ts
+++ b/src/features/fetchList/list.model.ts
@@ -1,0 +1,13 @@
+export interface ListInterface {
+  id: number;
+  date: string;
+  emotion: string;
+  dayInfo: DayInfo;
+  answerList: any;
+}
+
+interface DayInfo {
+  today: number;
+  month: string;
+  day: string;
+}


### PR DESCRIPTION
- DiarySlice에서 선언한 interface 를 정리하여 diary.model.ts로 옮김
- diary.model.ts에서 interface를 선언하고 이를 import하여 쓰는 코드로 변경
- DiarySlice에서 작성하는 다이어리의 interface와 작성된 다이어리
  리스트의 interface를 함께 관리하다보니 interface의 내용들이 섞여 이를 수정
- 다이어리를 작성하는 내용은 DiarySlice와 diary.model.ts로 관리.
- 작성된 다이어리는 fetchListSlice.ts와 list.model.ts 에서 관리.
- 바뀐 interface를 맞춰 컴포넌트의 코드 수정(main, diaryrecord question 등)