### PR TITLE
[ADD] DiaryDetail 컴포넌트 추가

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -8,6 +8,7 @@ import Main from './components/Main';
 import Emotion from './components/diary/Emotion';
 import Question from './components/diary/Question';
 import DiarySlider from './components/diary/DiarySlider';
+import DiaryDetail from './components/diaryDetail/DiaryDetail';
 
 const Routes = () => {
   return (
@@ -20,6 +21,7 @@ const Routes = () => {
         <Route exact path="/emotion" component={Emotion} />
         <Route exact path="/question" component={Question} />
         <Route exact path="/diary" component={DiarySlider} />
+        <Route exact path="/diary_detail/:id" component={DiaryDetail} />
       </Switch>
     </BrowserRouter>
   );

--- a/src/components/diaryDetail/DiaryDetail.scss
+++ b/src/components/diaryDetail/DiaryDetail.scss
@@ -1,0 +1,71 @@
+@import "../../styles/reset.scss";
+@import "../../styles/mixins";
+
+.diary_detail_wrap {
+    @include wrap;
+    background-color: #fff;
+    border: 1px solid #000;
+    .edit_btn {
+        width: 50px;
+        height: 30px;
+        background-color: transparent;
+        border: 1px solid #000;
+        cursor: pointer;
+        transition: 0.4s;
+        &:hover {
+            background: red;
+        }
+        &:active{
+            transform: scale(0.9);
+        }
+    }
+    .diary_detail_header {
+        //border: 1px solid red;
+        border-bottom: 2px solid #000;
+        width:90%;
+        margin: 10px auto;
+        height: 40px;
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+       .diary_detail_date {
+          //font-family: 'Cormorant', serif;
+          font-size: 20px;
+          font-weight: bold;
+       }
+       .diary_detail_emotion {
+           font-size: 20px;
+       }
+    }
+    .diary_detail_section {
+        width: 90%;
+        margin: 20px auto;
+        .detail_article, .edit_article {
+            //border: 1px solid red;
+            padding: 10px;
+            margin-bottom: 30px;
+            .detail_question {
+                font-weight: bold;
+                font-size: 20px;
+            }
+            .detail_answer {
+                margin-top: 10px;
+                font-size: 18px;
+            }
+        }
+        .edit_article {
+            border: 1px solid #000;
+            border-radius: 5px;
+            background-color: #dadada;
+            .edit_textarea{
+                width: 100%;
+                background: transparent;
+                height: 100px;
+                font-size: 15px;
+                border: none;
+                margin-top: 10px;
+                font-weight: bold;
+            }
+        }
+    }
+}

--- a/src/components/diaryDetail/DiaryDetail.tsx
+++ b/src/components/diaryDetail/DiaryDetail.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useEffect, ReactEventHandler } from 'react';
+import './DiaryDetail.scss';
+import { RouteComponentProps } from 'react-router';
+//import { Link } from 'react-router-dom';
+
+import { IconContext } from 'react-icons';
+import {
+  BiHappyAlt,
+  BiAngry,
+  BiSmile,
+  BiMeh,
+  BiSad,
+  BiXCircle,
+  BiX
+} from 'react-icons/bi';
+
+import { useAppSelector, useAppDispatch } from '../../app/hooks';
+
+const DiaryDetail: React.FC = (props: any) => {
+  const { record } = props.location.state;
+  console.log(props);
+
+  const questionList = useAppSelector((state) => state.diary.questionList);
+
+  const [answerArr, setAnswerArr] = useState<any>();
+  const [answerStr, setAnswerStr] = useState<any>();
+  const [edit, setEdit] = useState(false);
+  const [loadedList, setLoadedList] = useState<any>();
+
+  useEffect(() => {
+    const newAnswerList = arrToString(record.answerList);
+    setAnswerArr(record.answerList);
+    setAnswerStr(newAnswerList);
+    const fetchloadedList = localStorage.getItem('diary_list');
+    if (fetchloadedList) {
+      const load = JSON.parse(fetchloadedList);
+      setLoadedList(load);
+    }
+  }, []);
+
+  const arrToString = (obj: any) => {
+    let result: any = {};
+    for (let key in obj) {
+      result[key] = obj[key].toString().replaceAll(',', `\n`);
+    }
+    return result;
+  };
+
+  const renderEmotion = (emotion: string) => {
+    return (
+      <span>
+        {emotion === 'great' && <BiHappyAlt />}
+        {emotion === 'good' && <BiSmile />}
+        {emotion === 'okay' && <BiMeh />}
+        {emotion === 'not good' && <BiSad />}
+        {emotion === 'not great' && <BiAngry />}
+      </span>
+    );
+  };
+
+  const renderAnswerList = () => {
+    return questionList.map((question, index) => {
+      return (
+        <div className={edit ? `edit_article` : `detail_article`} key={index}>
+          <div className="detail_question">{question}</div>
+          {question && answerArr && !edit && renderAnswer(question, index)}
+          {question && answerStr && edit && renderText(question, index)}
+        </div>
+      );
+    });
+  };
+
+  const renderAnswer = (question: any, parentIdx: any) => {
+    return answerArr[question].map((answer: string, index: any) => {
+      const newKey = parentIdx.toString() + index.toString();
+      return (
+        <div className="detail_answer" key={newKey}>
+          {answer}
+        </div>
+      );
+    });
+  };
+
+  const renderText = (question: any, parentIdx: any) => {
+    return (
+      <textarea
+        className="edit_textarea"
+        key={parentIdx}
+        value={answerStr[question]}
+        name={question}
+        onChange={handleChange}
+      ></textarea>
+    );
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    const newAnswerStr = { ...answerStr, [name]: value };
+    const newAnswerArr = { ...answerArr, [name]: value.split(`\n`) };
+    setAnswerStr(newAnswerStr);
+    setAnswerArr(newAnswerArr);
+  };
+
+  const handleEdit = () => {
+    const newRecord = { ...record, answerList: answerArr };
+
+    const newList = loadedList.map((el: any) => {
+      if (el.id == newRecord.id) {
+        return newRecord;
+      } else {
+        return el;
+      }
+    });
+
+    localStorage.setItem('diary_list', JSON.stringify(newList));
+    setEdit(!edit);
+  };
+
+  const handleDelete = () => {
+    const newList = loadedList.filter((el: any) => el['id'] !== record['id']);
+    localStorage.setItem('diary_list', JSON.stringify(newList));
+    //history.push('/main');
+    //props.history.push('/main');
+  };
+
+  return (
+    <div className="diary_detail_wrap">
+      <button className="edit_btn" onClick={() => handleEdit()}>
+        {edit ? `Done` : 'Edit'}
+      </button>
+      <button className="delete_btn" onClick={() => handleDelete()}>
+        Delete
+      </button>
+      <div className="diary_detail_header">
+        <div className="diary_detail_date">{record.date}</div>
+        <div className="diary_detail_emotion">
+          <IconContext.Provider value={{ color: '#2c2c2c' }}>
+            {renderEmotion(record.emotion)}
+          </IconContext.Provider>
+        </div>
+      </div>
+      <div className="diary_detail_section">{renderAnswerList()}</div>
+    </div>
+  );
+};
+
+export default DiaryDetail;

--- a/src/components/diaryList/DiaryRecord.tsx
+++ b/src/components/diaryList/DiaryRecord.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import './DiaryRecord.scss';
 
+import { Link } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router';
+
 interface DiaryRecordProps {
   record: any;
 }
@@ -8,15 +11,28 @@ interface DiaryRecordProps {
 const DiaryRecord: React.FC<DiaryRecordProps> = (props) => {
   const { record } = props;
 
+  const handleClick = () => {
+    console.log('record:', record);
+  };
+
   return (
-    <div className="list_wrap">
+    <div className="list_wrap" onClick={() => handleClick()}>
       <div className="list_date_box">
         <div className="list_day">{record.dayInfo.day}</div>
         <div className="list_date">{record.dayInfo.today}</div>
       </div>
-      <div className="list_content_box">
-        {record.answerList['오늘의 다짐'][0]}
-      </div>
+      <Link
+        to={{
+          pathname: `/diary_detail/${record.id}`,
+          state: {
+            record: record
+          }
+        }}
+      >
+        <div className="list_content_box">
+          {record.answerList['오늘의 다짐'][0]}
+        </div>
+      </Link>
     </div>
   );
 };

--- a/src/components/diaryList/DiaryRecordList.tsx
+++ b/src/components/diaryList/DiaryRecordList.tsx
@@ -5,7 +5,6 @@ import DiaryRecord from './DiaryRecord';
 import { useAppSelector } from '../../app/hooks';
 
 const DiaryRecordList: React.FC = () => {
-  //const list = useAppSelector((state) => state.diary.list);
   const list = useAppSelector((state) => state.list.totalList);
 
   const renderList = () => {

--- a/src/components/todayInfo/TodayInfo.tsx
+++ b/src/components/todayInfo/TodayInfo.tsx
@@ -36,9 +36,6 @@ const TodayInfo: React.FC = () => {
     }
   }, [currentDate, list]);
 
-  console.log(dayCheck);
-  console.log(list);
-
   return (
     // <>
     // {!dayCheck ? (

--- a/src/components/todayRecord/TodayRecord.tsx
+++ b/src/components/todayRecord/TodayRecord.tsx
@@ -21,6 +21,8 @@ const TodayRecord: React.FC = () => {
     });
   };
 
+  console.log('select', selectList);
+
   const renderAnswer = (question: string, parentIndex: any) => {
     //console.log(typeof parentIndex);
     //console.log('parentIndex', parentIndex);

--- a/src/features/diary/diary.model.ts
+++ b/src/features/diary/diary.model.ts
@@ -3,6 +3,7 @@ export interface DiaryData {
   questionList: string[];
   //list: List[]; // 전체 다이어리 리스트를 관리하는 state 위치에 대해 고민이 필요하다.
   answerList: AnswerList;
+  edit: boolean;
 }
 
 interface List {

--- a/src/features/diary/diarySlice.ts
+++ b/src/features/diary/diarySlice.ts
@@ -40,7 +40,8 @@ const initialState: DiaryData = {
     '내가 감사하게 생각하는 것들': ['1. '],
     '오늘을 기분좋게 만들어주는 것은?': ['1. '],
     '오늘의 다짐': ['1. ']
-  }
+  },
+  edit: false
 };
 
 export const diarySlice = createSlice({
@@ -66,11 +67,16 @@ export const diarySlice = createSlice({
         ...state.answerList,
         [question]: value.split('\n')
       };
+    },
+    handleEdit: (state, action: any) => {
+      state.edit = !state.edit;
+      // state.emotion = action.payload.emotion;
+      // state.answerList = action.payload.answerList;
     }
   }
 });
 
-export const { handleEmotion, handleAnswer } = diarySlice.actions;
+export const { handleEmotion, handleAnswer, handleEdit } = diarySlice.actions;
 
 export const diary = (state: RootState) => state.diary;
 


### PR DESCRIPTION
- 작성한 다이어리의 상세 내용을 볼 수 있는 DiaryDetail 컴포넌트 추가.
- 기록한 기분, 질문에 대한 답을 볼 수 있는 페이지.
- 기분을 제외한 각 질문에 대한 답을 편집할 수 있는 기능 구현.
- 편집시, 로컬스토리지에 있는 기존의 데이터도 변환.
- 삭제 기능 추가.
- 삭제시, 로컬스토리지에 있는 데이터 삭제.
- 현재 데이터를 삭제해도 Main 페이지에서 selectList라는 state 값이 남아
  있어 localStorage에 데이터가 없어도 TodayRecord 컴포넌트를 보여주는
  오류 확인