### PR TITLE
[Fix] DiaryDetail scss 코드 수정

### DIFF
--- a/src/components/diaryDetail/DiaryDetail.scss
+++ b/src/components/diaryDetail/DiaryDetail.scss
@@ -7,6 +7,7 @@
     border: 1px solid #000;
     font-style: 'Open Sans', sans-serif;
     color: #fff;
+    position: relative;
     .diary_detail_header {
         //border: 1px solid red;
         border-bottom: 2px solid #fff;
@@ -85,10 +86,9 @@
         }
     }
     .diary_detail_footer {
-        position: fixed;
-        width: 340px;
-        left: 348px;
-        bottom: 20px;
+       position: absolute;
+       left: 5%;
+       bottom: 5%;
         .confirm_btn {
             font-size: 30px;
             border:none;


### PR DESCRIPTION
- diary_detail_footer의 position이 기존에는 fixed라 화면 크기에 따라 오류 발생(해당 div가 안 보임)
- diary_detail_wrap의 position relative 추가, diary_detail_footer의 position absolute로 변경
-  diary_detail_footer의 left, bottom 퍼센트로 수정